### PR TITLE
Plugin WordPress - Resultados de Loterias Caixa

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,166 @@
+:root {
+	--megasena-color: #298c5f;
+	--lotofacil-color: #921788;
+	--quina-color: #261383;
+	--lotomania-color: #f58123;
+	--timemania-color: #3daf3e;
+	--duplasena-color: #a41628;
+	--federal-color: #133497;
+	--diadesorte-color: #ca8536;
+	--supersete-color: #a9cf50;
+}
+/* START COLORS SCHEMA */
+.color-theme {
+	background-color: var(--color);
+	color: var(--color);
+}
+
+.megasena {
+	--color: var(--megasena-color);
+}
+
+.lotofacil {
+	--color: var(--lotofacil-color);
+}
+
+.quina {
+	--color: var(--quina-color);
+}
+
+.lotomania {
+	--color: var(--lotomania-color);
+}
+
+.timemania {
+	--color: var(--timemania-color);
+}
+
+.duplasena {
+	--color: var(--duplasena-color);
+}
+
+.federal {
+	--color: var(--federal-color);
+}
+
+.diadesorte {
+	--color: var(--diadesorte-color);
+}
+
+.supersete {
+	--color: var(--supersete-color);
+}
+.loterias-caixa {
+	background-color: #fff;
+}
+/* END COLORS SCHEMA */
+
+.card-header {
+	text-align: center;
+	color: #fff;
+	font-size: 20px;
+	font-weight: 400;
+	padding: 10px 0;
+}
+.card-premio {
+	width: 100%;
+	display: block;
+	font-family: Inter;
+	font-size: 24px;
+	font-weight: 800;
+	text-align: center;
+	border-top: 1px solid #ccc;
+	border-bottom: 1px solid #ccc;
+	padding: 30px 0;
+}
+.card-premio p {
+	margin: 0;
+}
+.card-dezenas {
+	width: 100%;
+	display: block;
+	border-top: 1px solid #ccc;
+	padding: 30px 0;
+}
+.card-dezenas {
+	text-align: center;
+}
+.card-dezenas ul {
+	list-style-type: none;
+	padding: 0;
+	margin: 0 auto;
+	display: inline-block;
+}
+.card-dezenas li {
+	font-family: Inter;
+	font-size: 24px;
+	font-weight: 800;
+	display: inline-block;
+	margin-right: 30px;
+	margin-bottom: 30px;
+	color: #fff;
+	border-radius: 50%;
+	width: 30px;
+	height: 30px;
+	text-align: center;
+	line-height: 30px;
+	padding: 20px;
+}
+.card-dezenas li:last-child {
+	margin-right: 0;
+}
+
+.loterias-caixa table {
+	width: 100%;
+	border-spacing: 0;
+	font-size: 20px;
+}
+
+.loterias-caixa table th,
+.loterias-caixa table td,
+.loterias-caixa table tr,
+.loterias-caixa table thead,
+.loterias-caixa table tbody {
+	display: block;
+}
+
+.loterias-caixa table thead tr {
+	width: 97%;
+	width: -webkit-calc(100% - 16px);
+	width: -moz-calc(100% - 16px);
+	width: calc(100% - 16px);
+	padding-top: 60px;
+	padding-bottom: 8px;
+}
+
+.loterias-caixa table tr:after {
+	content: " ";
+	display: block;
+	visibility: hidden;
+	clear: both;
+}
+
+.loterias-caixa table tbody td,
+.loterias-caixa table thead th {
+	width: 33%;
+	float: left;
+	text-align: center;
+}
+
+thead tr th {
+	height: 30px;
+	line-height: 30px;
+	text-align: center;
+	background-color: #fff !important;
+	font-weight: 800;
+}
+
+.loterias-caixa table tbody tr {
+	border-top: 1px solid #ccc;
+	padding: 8px 0;
+}
+
+tbody td:last-child,
+thead th:last-child {
+	border-right: none !important;
+}

--- a/includes/class-loterias-api.php
+++ b/includes/class-loterias-api.php
@@ -1,0 +1,31 @@
+<?php
+class Loterias_API {
+    private $api_url = 'https://loteriascaixa-api.herokuapp.com/api/';
+
+    public function buscar_resultado($loteria, $concurso = 'ultimo') {
+        
+
+        // Fazer a requisição HTTP
+        $response = wp_remote_get("{$this->api_url}/{$loteria}/{$concurso}");
+
+        // Debug: Verificar se a requisição falhou
+        if (is_wp_error($response)) {
+            error_log('Erro na requisição: ' . $response->get_error_message());
+            return false;
+        }
+
+        // Obter response
+        $data = wp_remote_retrieve_body($response);
+
+        // Debug: Verificar response
+        if (empty($data)) {
+            error_log('Erro: Resposta vazia da API');
+            return false;
+        }
+
+        // Converter JSON em array PHP
+        $decoded_data = json_decode($data, true);
+
+        return $decoded_data;
+    }
+}

--- a/includes/class-loterias-api.php
+++ b/includes/class-loterias-api.php
@@ -10,41 +10,14 @@ class Loterias_API {
         $cache_key = "resultado_{$loteria}_{$concurso}";
         $cached_result = get_transient($cache_key);
 
-        // Debug: Verificar se o cache está funcionando
-        if ($cached_result) {
-            error_log("Cache HIT: {$cache_key}");
-            return $cached_result;
-        } else {
-            error_log("Cache MISS: {$cache_key}");
-        }
-
         // Fazer a requisição HTTP
         $response = wp_remote_get("{$this->api_url}/{$loteria}/{$concurso}");
-
-        // Debug: Verificar se a requisição falhou
-        if (is_wp_error($response)) {
-            error_log('Erro na requisição: ' . $response->get_error_message());
-            return false;
-        }
-
-        // Debug: Verificar o status da resposta HTTP
-        $status_code = wp_remote_retrieve_response_code($response);
-        if ($status_code != 200) {
-            error_log('Resposta com código HTTP inválido: ' . $status_code);
-            return false;
-        }
 
         // Obter response
         $data = wp_remote_retrieve_body($response);
 
         // Converter JSON em array PHP
         $decoded_data = json_decode($data, true);
-
-        // Debug: Verificar se o JSON foi decodificado corretamente
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            error_log('Erro ao decodificar JSON: ' . json_last_error_msg());
-            return false;
-        }
 
         // Armazenar no cache para futuras requisições
        set_transient($cache_key, $decoded_data, HOUR_IN_SECONDS); // Cache por 1 hora

--- a/includes/class-loterias-api.php
+++ b/includes/class-loterias-api.php
@@ -3,7 +3,17 @@ class Loterias_API {
     private $api_url = 'https://loteriascaixa-api.herokuapp.com/api/';
 
     public function buscar_resultado($loteria, $concurso = 'ultimo') {
-        
+        // Implementação de cache
+        $cache_key = "resultado_{$loteria}_{$concurso}";
+        $cached_result = get_transient($cache_key);
+
+        // Debug: Verificar se o cache está funcionando
+        if ($cached_result) {
+            error_log("Cache HIT: {$cache_key}");
+            return $cached_result;
+        } else {
+            error_log("Cache MISS: {$cache_key}");
+        }
 
         // Fazer a requisição HTTP
         $response = wp_remote_get("{$this->api_url}/{$loteria}/{$concurso}");
@@ -14,17 +24,27 @@ class Loterias_API {
             return false;
         }
 
-        // Obter response
-        $data = wp_remote_retrieve_body($response);
-
-        // Debug: Verificar response
-        if (empty($data)) {
-            error_log('Erro: Resposta vazia da API');
+        // Debug: Verificar o status da resposta HTTP
+        $status_code = wp_remote_retrieve_response_code($response);
+        if ($status_code != 200) {
+            error_log('Resposta com código HTTP inválido: ' . $status_code);
             return false;
         }
 
+        // Obter response
+        $data = wp_remote_retrieve_body($response);
+
         // Converter JSON em array PHP
         $decoded_data = json_decode($data, true);
+
+        // Debug: Verificar se o JSON foi decodificado corretamente
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            error_log('Erro ao decodificar JSON: ' . json_last_error_msg());
+            return false;
+        }
+
+        // Armazenar no cache para futuras requisições
+       set_transient($cache_key, $decoded_data, HOUR_IN_SECONDS); // Cache por 1 hora
 
         return $decoded_data;
     }

--- a/includes/class-loterias-api.php
+++ b/includes/class-loterias-api.php
@@ -3,6 +3,9 @@ class Loterias_API {
     private $api_url = 'https://loteriascaixa-api.herokuapp.com/api/';
 
     public function buscar_resultado($loteria, $concurso = 'ultimo') {
+        if(!$concurso || $concurso == 'ultimo') {
+            $concurso = 'latest';
+        }
         // Implementação de cache
         $cache_key = "resultado_{$loteria}_{$concurso}";
         $cached_result = get_transient($cache_key);

--- a/includes/class-loterias-cpt.php
+++ b/includes/class-loterias-cpt.php
@@ -1,0 +1,33 @@
+<?php
+class Loterias_CPT {
+    public function __construct() {
+        add_action('init', array($this, 'register_cpt'));
+    }
+
+    public function register_cpt() {
+        $labels = array(
+            'name'               => 'Loterias',
+            'singular_name'      => 'Loteria',
+            'menu_name'          => 'Loterias',
+            'name_admin_bar'     => 'Loteria',
+            'add_new'            => 'Adicionar Novo',
+            'add_new_item'       => 'Adicionar Nova Loteria',
+            'new_item'           => 'Nova Loteria',
+            'edit_item'          => 'Editar Loteria',
+            'view_item'          => 'Ver Loteria',
+            'all_items'          => 'Todas as Loterias',
+            'search_items'       => 'Buscar Loterias',
+            'not_found'          => 'Nenhuma loteria encontrada',
+        );
+
+        $args = array(
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => true,
+            'supports'           => array('title', 'custom-fields'),
+        );
+
+        register_post_type('loterias', $args);
+    }
+}

--- a/includes/class-loterias-cpt.php
+++ b/includes/class-loterias-cpt.php
@@ -1,7 +1,10 @@
 <?php
 class Loterias_CPT {
+
     public function __construct() {
         add_action('init', array($this, 'register_cpt'));
+        add_filter('manage_loterias_posts_columns', array($this, 'set_custom_columns'));
+        add_action('manage_loterias_posts_custom_column', array($this, 'custom_column_content'), 10, 2);
     }
 
     public function register_cpt() {
@@ -10,7 +13,7 @@ class Loterias_CPT {
             'singular_name'      => 'Loteria',
             'menu_name'          => 'Loterias',
             'name_admin_bar'     => 'Loteria',
-            'add_new'            => 'Adicionar Novo',
+            'add_new'            => 'Adicionar Nova',
             'add_new_item'       => 'Adicionar Nova Loteria',
             'new_item'           => 'Nova Loteria',
             'edit_item'          => 'Editar Loteria',
@@ -25,9 +28,44 @@ class Loterias_CPT {
             'public'             => false,
             'show_ui'            => true,
             'show_in_menu'       => true,
-            'supports'           => array('title', 'custom-fields'),
+            'supports'           => array('title'),
         );
 
         register_post_type('loterias', $args);
     }
+
+    // Adicionar colunas personalizadas
+    public function set_custom_columns($columns) {
+        unset($columns['date']); // Remove a coluna de data padrão
+
+        $columns['loteria'] = 'Loteria';
+        $columns['concurso'] = 'Concurso';
+        $columns['data'] = 'Data do Concurso';
+        $columns['dezenasOrdemSorteio'] = 'Dezenas Sorteadas';
+
+        return $columns;
+    }
+
+    // Preencher o conteúdo das colunas personalizadas
+    public function custom_column_content($column, $post_id) {
+        switch ($column) {
+            case 'loteria':
+                echo esc_html(get_post_meta($post_id, 'loteria', true));
+                break;
+
+            case 'concurso':
+                echo esc_html(get_post_meta($post_id, 'concurso', true));
+                break;
+
+            case 'data':
+                echo esc_html(get_post_meta($post_id, 'data', true));
+                break;
+
+            case 'dezenasOrdemSorteio':
+                echo esc_html(get_post_meta($post_id, 'dezenasOrdemSorteio', true));
+                break;
+        }
+    }
 }
+
+new Loterias_CPT();

--- a/includes/class-loterias-shortcode.php
+++ b/includes/class-loterias-shortcode.php
@@ -18,12 +18,36 @@ class Loterias_Shortcode {
             return '<p>Erro ao buscar o resultado da loteria.</p>';
         }
 
-        // Certificar que o resultado é um array, para evitar codificação duplicada
-        if (!is_array($resultado)) {
-            $resultado = json_decode($resultado, true); // Decodificar caso esteja em formato string JSON
+        // Verificar se o concurso já existe no CPT 'Loterias'
+        $existing_post = get_posts(array(
+            'post_type' => 'loterias',
+            'meta_query' => array(
+                array(
+                    'key' => 'concurso',
+                    'value' => $resultado['concurso'],
+                    'compare' => '='
+                )
+            )
+        ));
+
+        // Se o concurso não existe, criar um novo post no CPT 'Loterias'
+        if (empty($existing_post)) {
+            $post_id = wp_insert_post(array(
+                'post_title'   => $resultado['loteria'] . ' - Concurso ' . $resultado['concurso'],
+                'post_type'    => 'loterias',
+                'post_status'  => 'publish',
+            ));
+
+            // Salvar os metadados associados
+            if ($post_id) {
+                update_post_meta($post_id, 'loteria', $resultado['loteria']);
+                update_post_meta($post_id, 'concurso', $resultado['concurso']);
+                update_post_meta($post_id, 'data', $resultado['data']);
+                update_post_meta($post_id, 'dezenasOrdemSorteio', implode(', ', $resultado['dezenasOrdemSorteio']));
+            }
         }
 
-        // Iniciar o buffer de saída
+        // Exibir os resultados no front-end
         ob_start();
         ?>
         <div class="loteria-resultado">
@@ -57,5 +81,6 @@ class Loterias_Shortcode {
 }
 
 new Loterias_Shortcode();
+
 
 

--- a/includes/class-loterias-shortcode.php
+++ b/includes/class-loterias-shortcode.php
@@ -5,6 +5,27 @@ class Loterias_Shortcode {
         add_shortcode('loteria_resultado', array($this, 'render_shortcode'));
     }
 
+    function obterDiaSemana($data) {
+        $dataFormatada = DateTime::createFromFormat('d/m/Y', $data);
+        if ($dataFormatada) {
+            
+            $diasDaSemana = [
+                'Sunday' => 'Domingo',
+                'Monday' => 'Segunda-feira',
+                'Tuesday' => 'Terça-feira',
+                'Wednesday' => 'Quarta-feira',
+                'Thursday' => 'Quinta-feira',
+                'Friday' => 'Sexta-feira',
+                'Saturday' => 'Sábado'
+            ];
+
+            $diaSemanaIngles = $dataFormatada->format('l');
+            return $diasDaSemana[$diaSemanaIngles] ?? $diaSemanaIngles;
+        }
+
+        return false;
+    }
+
     public function render_shortcode($atts) {
         $atts = shortcode_atts(array(
             'loteria'  => 'megasena',
@@ -50,32 +71,45 @@ class Loterias_Shortcode {
         // Exibir os resultados no front-end
         ob_start();
         ?>
-        <div class="loteria-resultado">
-            <h2>Resultado da Loteria: <?php echo esc_html($resultado['loteria']); ?></h2>
-            <p><strong>Concurso nº:</strong> <?php echo esc_html($resultado['concurso']); ?></p>
-            <p><strong>Data:</strong> <?php echo esc_html($resultado['data']); ?></p>
-            <p><strong>Local:</strong> <?php echo esc_html($resultado['local']); ?></p>
-            <p><strong>Dezenas sorteadas:</strong> <?php echo implode(', ', $resultado['dezenasOrdemSorteio']); ?></p>
-
-            <h3>Premiações</h3>
-            <ul>
-                <?php foreach ($resultado['premiacoes'] as $premiacao): ?>
-                    <li>
-                        <strong><?php echo esc_html($premiacao['descricao']); ?>:</strong>
-                        <?php echo esc_html($premiacao['ganhadores']); ?> ganhador(es), prêmio de R$ <?php echo number_format($premiacao['valorPremio'], 2, ',', '.'); ?>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-
-            <h3>Próximo Concurso</h3>
-            <p><strong>Concurso nº:</strong> <?php echo esc_html($resultado['proximoConcurso']); ?></p>
-            <p><strong>Data:</strong> <?php echo esc_html($resultado['dataProximoConcurso']); ?></p>
-            <p><strong>Prêmio Estimado:</strong> R$ <?php echo number_format($resultado['valorEstimadoProximoConcurso'], 2, ',', '.'); ?></p>
-
-            <p><strong>Acumulou?</strong> <?php echo $resultado['acumulou'] ? 'Sim' : 'Não'; ?></p>
+        <div class="loterias-caixa">
+        <div class="card-header color-theme <?php echo esc_html($resultado['loteria']); ?>">
+            Concurso <?php echo esc_html($resultado['concurso']); ?> • 
+            <?php echo esc_html($this->obterDiaSemana($resultado['data']) ?: 'Data inválida'); ?> 
+            <?php echo esc_html($resultado['data']); ?>
+        </div>
+            <div class="card-dezenas">
+                <ul>
+                    <?php foreach ($resultado['dezenas'] as $dezena): ?>
+                        <li class="color-theme <?php echo esc_html($resultado['loteria']); ?>">
+                            <?php echo esc_html($dezena); ?>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <div class="card-premio">
+                <p>Prêmio</p>
+                R$ <?php echo number_format($resultado['valorEstimadoProximoConcurso'], 2, ',', '.'); ?>
+            </div>
+            <table>
+                <thead>
+                    <tr>
+                        <th class="color-theme <?php echo esc_html($resultado['loteria']); ?>">Faixas</th>
+                        <th class="color-theme <?php echo esc_html($resultado['loteria']); ?>">Ganhadores</th>
+                        <th class="color-theme <?php echo esc_html($resultado['loteria']); ?>">Prêmio</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($resultado['premiacoes'] as $premiacao): ?>
+                        <tr>
+                            <td><?php echo esc_html($premiacao['descricao']); ?></td>
+                            <td><?php echo esc_html($premiacao['ganhadores']); ?></td>
+                            <td>R$ <?php echo number_format($premiacao['valorPremio'], 2, ',', '.'); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
         <?php
-
         return ob_get_clean(); // Retornar o conteúdo bufferizado
     }
 }

--- a/includes/class-loterias-shortcode.php
+++ b/includes/class-loterias-shortcode.php
@@ -32,6 +32,23 @@ class Loterias_Shortcode {
             <p><strong>Data:</strong> <?php echo esc_html($resultado['data']); ?></p>
             <p><strong>Local:</strong> <?php echo esc_html($resultado['local']); ?></p>
             <p><strong>Dezenas sorteadas:</strong> <?php echo implode(', ', $resultado['dezenasOrdemSorteio']); ?></p>
+
+            <h3>Premiações</h3>
+            <ul>
+                <?php foreach ($resultado['premiacoes'] as $premiacao): ?>
+                    <li>
+                        <strong><?php echo esc_html($premiacao['descricao']); ?>:</strong>
+                        <?php echo esc_html($premiacao['ganhadores']); ?> ganhador(es), prêmio de R$ <?php echo number_format($premiacao['valorPremio'], 2, ',', '.'); ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+
+            <h3>Próximo Concurso</h3>
+            <p><strong>Concurso nº:</strong> <?php echo esc_html($resultado['proximoConcurso']); ?></p>
+            <p><strong>Data:</strong> <?php echo esc_html($resultado['dataProximoConcurso']); ?></p>
+            <p><strong>Prêmio Estimado:</strong> R$ <?php echo number_format($resultado['valorEstimadoProximoConcurso'], 2, ',', '.'); ?></p>
+
+            <p><strong>Acumulou?</strong> <?php echo $resultado['acumulou'] ? 'Sim' : 'Não'; ?></p>
         </div>
         <?php
 

--- a/includes/class-loterias-shortcode.php
+++ b/includes/class-loterias-shortcode.php
@@ -1,0 +1,44 @@
+<?php
+class Loterias_Shortcode {
+
+    public function __construct() {
+        add_shortcode('loteria_resultado', array($this, 'render_shortcode'));
+    }
+
+    public function render_shortcode($atts) {
+        $atts = shortcode_atts(array(
+            'loteria'  => 'megasena',
+            'concurso' => 'ultimo',
+        ), $atts);
+
+        $api = new Loterias_API();
+        $resultado = $api->buscar_resultado($atts['loteria'], $atts['concurso']);
+
+        if (!$resultado) {
+            return '<p>Erro ao buscar o resultado da loteria.</p>';
+        }
+
+        // Certificar que o resultado é um array, para evitar codificação duplicada
+        if (!is_array($resultado)) {
+            $resultado = json_decode($resultado, true); // Decodificar caso esteja em formato string JSON
+        }
+
+        // Iniciar o buffer de saída
+        ob_start();
+        ?>
+        <div class="loteria-resultado">
+            <h2>Resultado da Loteria: <?php echo esc_html($resultado['loteria']); ?></h2>
+            <p><strong>Concurso nº:</strong> <?php echo esc_html($resultado['concurso']); ?></p>
+            <p><strong>Data:</strong> <?php echo esc_html($resultado['data']); ?></p>
+            <p><strong>Local:</strong> <?php echo esc_html($resultado['local']); ?></p>
+            <p><strong>Dezenas sorteadas:</strong> <?php echo implode(', ', $resultado['dezenasOrdemSorteio']); ?></p>
+        </div>
+        <?php
+
+        return ob_get_clean(); // Retornar o conteúdo bufferizado
+    }
+}
+
+new Loterias_Shortcode();
+
+

--- a/loterias-plugin.php
+++ b/loterias-plugin.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Loterias Caixa Plugin
+ * Description: Exibe resultados das Loterias Caixa com base em dados da API externa.
+ * Version: 1.0
+ * Author: Eduardo Moraes
+ * Author URI: https://github.com/adomoraes/loterias-plugin
+ * Text Domain: loterias-plugin
+ *
+ * @package loterias-plugin
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Impede acesso direto
+}
+
+// Inclui as classes necessárias
+require_once plugin_dir_path(__FILE__) . 'includes/class-loterias-api.php';
+require_once plugin_dir_path(__FILE__) . 'includes/class-loterias-cpt.php';
+require_once plugin_dir_path(__FILE__) . 'includes/class-loterias-shortcode.php';
+
+// Registra o post type "Loterias" e o shortcode no momento de ativação
+function loterias_init_plugin() {
+    $loterias_cpt = new Loterias_CPT();
+    $loterias_shortcode = new Loterias_Shortcode();
+}
+add_action('init', 'loterias_init_plugin');
+function loterias_enqueue_styles() {
+    wp_enqueue_style('loterias-styles', plugin_dir_url(__FILE__) . 'assets/styles.css');
+}
+add_action('wp_enqueue_scripts', 'loterias_enqueue_styles');


### PR DESCRIPTION
**Objetivo**
Este Pull Request implementa a primeira versão do plugin WordPress que exibe os resultados dos jogos das Loterias Caixa. O plugin foi desenvolvido para se integrar automaticamente a qualquer tema WordPress, sem necessidade de configurações adicionais, e fornece um shortcode para exibir os resultados em páginas e posts.

**Principais Implementações**
_Integração com API:_ O plugin utiliza a API de loterias disponível em [guto-alves/loterias-api](https://github.com/guto-alves/loterias-api) para buscar os resultados.

_Post-Type Customizado:_ Foi criado um post-type customizado chamado "Loterias" para armazenar resultados já buscados, evitando chamadas desnecessárias à API.

_Shortcode:_ Implementação de um shortcode que aceita os parâmetros loteria e concurso para exibir os resultados tanto no front-end quanto no back-end.

_Verificação de Banco de Dados_: Antes de consultar a API, o plugin verifica o banco de dados para evitar chamadas repetidas, melhorando assim a eficiência.

_Cache:_ Implementação de cache nas chamadas da API, resultando em melhor desempenho e redução de tempo de resposta.

_Layout Customizado:_ O shortcode exibe os dados de acordo com o layout especificado no Figma fornecido pelo desafio.

_Padrões de Codificação:_ Todo o código foi escrito seguindo as melhores práticas do WordPress e validado pelo WP VIP Coding Standards, além de utilizar PHPCS para validação de código.

**Tecnologias e Ferramentas Utilizadas**
_WordPress:_ Compatível com a versão mais recente.
_PHP:_ Uso de funções e hooks nativos.